### PR TITLE
add `require 'rbconfig'`

### DIFF
--- a/lib/libui.rb
+++ b/lib/libui.rb
@@ -1,5 +1,6 @@
 require_relative 'libui/version'
 require_relative 'libui/utils'
+require 'rbconfig'
 
 module LibUI
   class Error < StandardError; end


### PR DESCRIPTION
LibUI needs RbConfig library, but it doesn't have `require 'rbconfig'` .

Normally, this is not a problem because Rubygems loads RbConfig, but if I try to use LibUI without Rubygems, I get the following error:

```
libui.rb:11:in `<module:LibUI>': uninitialized constant LibUI::RbConfig (NameError)
```

Also, there is no guarantee that Rubygems will load RbConfig in future versions. So I think it's better to load RbConfig in LibUI. 