### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build_ng.yml
+++ b/.github/workflows/build_ng.yml
@@ -23,7 +23,9 @@ jobs:
         if: ${{ matrix.os == 'ubuntu' }}
         run: |
           sudo apt update -yq
-          sudo apt install -yq meson ninja-build libgtk-3-dev
+          python3 -m pip install --upgrade pip setuptools wheel
+          pip3 install meson ninja # Workaround to install the latest meson
+          sudo apt install -yq libgtk-3-dev
       - name: Install meson ninja (macos)
         if: ${{ matrix.os == 'macos' }}
         run: |


### PR DESCRIPTION
Install latest meson.

Currently, the version of meson available through Apt is out of date, so when I try to build libuii-ng, I get the following error message.

```
The Meson build system
Version: 0.53.2
Source dir: /tmp/d20220924-4349-nysbof/libui-ng-master
Build dir: /tmp/d20220924-4349-nysbof/libui-ng-master/build
Build type: native build

meson.build:6:0: ERROR: Meson version is 0.53.2 but project requires >=0.58.0

A full log can be found at /tmp/d20220924-4349-nysbof/libui-ng-master/build/meson-logs/meson-log.txt
```

To work around this problem, use `pip` to get a newer meson. 
Personally, I do not like this workaround. However, the libui-ng repository also uses this method, so I think it is the best for the current situation.
