### PR TITLE
Fix editable_combobox in example2

### DIFF
--- a/examples2/editable_combobox.rb
+++ b/examples2/editable_combobox.rb
@@ -30,7 +30,7 @@ def populate_the_combobox_with_this_array(
   this_array.each {|this_entry|
     LibUI.editable_combobox_append(the_combobox, this_entry) # Here we add elements to the combobox.
   }
-  LibUI.combobox_set_selected(the_combobox, 0) # The first element is now the default selected entry.
+  LibUI.editable_combobox_set_text(the_combobox, this_array[0]) # Set first element as default text.
 end
 
 main_window = LibUI.new_window('combobox.rb', 640, 480, 1)
@@ -48,43 +48,31 @@ array = %w( matz created ruby as efficient alternative to perl )
 populate_the_combobox_with_this_array(_, array)
 
 # ============================================================================ #
-# Next showing how to clear it:
+# Note: uiEditableCombobox does not support clearing. Recreate if needed.
 # ============================================================================ #
-LibUI.combobox_clear(_)
-populate_the_combobox_with_this_array(_, array) # And re-populate it here.
 
 # ============================================================================ #
-# Next we delete the third entry; and then insert two new elements
-# at that former position, to showcase the functionality
-# combobox_delete, as well as combobox_insert_at. Note that combobox_delete
-# takes two arguments, whereas combobox_insert_at takes three arguments.
+# Note: uiEditableCombobox does not support delete or insert operations.
 # ============================================================================ #
-LibUI.combobox_delete(_, 2)
-LibUI.combobox_insert_at(_, 2, 'ruby')
 
 # ============================================================================ #
-# Show how many elements are in that combobox:
+# Note: uiEditableCombobox does not support counting items.
 # ============================================================================ #
-puts "The combobox we are using here has a total "\
-     "of #{LibUI.combobox_num_items(_)} elements."
-
-LibUI.combobox_set_selected(_, 3) # Change the selected element next, to item 4.
 
 # ============================================================================ #
-# Show the selected entry next:
+# Show the current text instead:
 # ============================================================================ #
-puts "The presently selected entry in our combobox is element number "\
-     "#{LibUI.combobox_selected(_)}."
+puts "The current text in our editable combobox is: "\
+     "#{LibUI.editable_combobox_text(_)}"
 
 puts 'Last but not least, try to change the combobox to a new value.'
-puts 'This will trigger LibUI.combobox_on_selected().'
+puts 'This will trigger LibUI.editable_combobox_on_changed().'
 
 # ============================================================================ #
 # Testing support for :editable_combobox_on_changed next.
 # ============================================================================ #
 LibUI.editable_combobox_on_changed(_) { |pointer|
-  selected = LibUI.combobox_selected(pointer)
-  puts "The new selection is element number `#{selected}`."
+  puts "The editable combobox text has changed."
   puts "The currently selected text is: `#{LibUI.editable_combobox_text(pointer)}`"
 }
 


### PR DESCRIPTION
libui-ng intentionally limits editable comboboxes to simple text get/set functionality. 
Since users can freely input text in an editable combobox, the concept of "which item is selected" becomes ambiguous.