### PR TITLE
Update macOS runner version in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         runner:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - windows-latest
         ruby: ["2.7", "3.2", "3.3", "3.4"]


### PR DESCRIPTION
Replaced macos-13 with macos-15-intel
See https://github.com/actions/runner-images/issues/13046